### PR TITLE
CONNECT-136

### DIFF
--- a/prusa/connect/printer/connection.py
+++ b/prusa/connect/printer/connection.py
@@ -12,11 +12,11 @@ class Connection:
     def make_headers(self, timestamp: int) -> dict:
         """Return request headers from connection variables."""
         headers = {
-            "Printer-Fingerprint": self.fingerprint,
+            "Fingerprint": self.fingerprint,
             "Timestamp": str(timestamp)
         }
         if self.token:
-            headers['Printer-Token'] = self.token
+            headers['Token'] = self.token
         return headers
 
     def post(self, url: str, headers: dict, data: dict):

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -16,7 +16,7 @@ def test_connection_anonym(requests_mock):
 
     conn = Connection(SERVER, FINGERPRINT)
     headers = conn.make_headers(123)
-    assert headers == {"Printer-Fingerprint": FINGERPRINT,
+    assert headers == {"Fingerprint": FINGERPRINT,
                        "Timestamp": "123"}
 
     conn.post("/p/test", headers, {'key': 'val'})
@@ -29,8 +29,8 @@ def test_make_headers(requests_mock):
 
     conn = Connection(SERVER, FINGERPRINT, TOKEN)
     headers = conn.make_headers(123)
-    assert headers == {"Printer-Fingerprint": FINGERPRINT,
-                       "Printer-Token": TOKEN,
+    assert headers == {"Fingerprint": FINGERPRINT,
+                       "Token": TOKEN,
                        "Timestamp": "123"}
     conn.post("/p/test", headers, {'key': 'val'})
     conn.get("/p/test", headers)


### PR DESCRIPTION
* add support for `POST /p/register` and `GET /p/register` to SDK
* Remove `Printer-` prefix for `Fingerprint` and `Token`