### PR TITLE
Add `fs` object to Printer along w. `mount()` and `unmount()`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 requests
 inotify_simple
-blinker


### PR DESCRIPTION
This also removes usage of `blinker`, potentially harmless if Printer was used as singleton object, but troublesome if there were multiple instances like in test.