### PR TITLE
Fix handling of adding folder subtrees to a tracked folder

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -16,6 +16,7 @@ ChangeLog
     * Removed ready information from get_info and event_cb functions
     * 400 responses handling change
     * 403 response handling change
+    * Fix handling of the addition of file subtrees
 
 0.6.0 (2021-12-17)
     * Introduce `const.State.PREPARED`


### PR DESCRIPTION
I do not understand the SDK and the way it is, just trying to make it do things it is supposed to do.

The inotify handler seems like the de-facto way of adding files to the tree, but no event exists for the files that have been added in a subfolder, so we have to fake some, but the filename filtering is done in the event handling before the handler, so we have to filter the fake calls beforehand ourselves

