### PR TITLE
chore(release): bump version to 0.8.2

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,10 @@
 ChangeLog
 =========
+0.8.2 (2025-05-05)
+    * Bump requests to 2.32.3
+    * Set TLS config value fallabck to False
+    * Python 3.11 and 3.12 check
+
 0.8.1 (2024-06-25)
     * Skip hidden sub-directories
     * Sync files upon Transfer finish

--- a/prusa/connect/printer/__init__.py
+++ b/prusa/connect/printer/__init__.py
@@ -35,9 +35,9 @@ from .models import (
 )
 from .util import RetryingSession, get_timestamp
 
-__version__ = "0.8.1"
-__date__ = "25 Jun 2024"  # version date
-__copyright__ = "(c) 2024 Prusa 3D"
+__version__ = "0.8.2"
+__date__ = "5 May 2025"  # version date
+__copyright__ = "(c) 2025 Prusa 3D"
 __author_name__ = "Prusa Link Developers"
 __author_email__ = "link@prusa3d.cz"
 __author__ = f"{__author_name__} <{__author_email__}>"


### PR DESCRIPTION
Last maintenance relase of the Prusa SDK. Version 0.8.2. No major changes.

I created a tag 0.8.2 in my fork pointing to this version bump commit.
After merging, please consider creating the same tag in the upstream repo, pointing to the merged commit b3430ad0a080f846b99a344740f664c0f93acf37, to keep versioning consistent.