### PR TITLE
fix: resolve mypy and pytest compatibility issues

### DIFF
--- a/prusa/connect/printer/__init__.py
+++ b/prusa/connect/printer/__init__.py
@@ -652,8 +652,9 @@ class Printer:
         """
         if res.status_code == 200:
             command_id: Optional[int] = None
+            command_id_string: str
             try:
-                command_id_string = res.headers.get("Command-Id", default="")
+                command_id_string = res.headers.get("Command-Id", "")
                 command_id = int(command_id_string)
             except (TypeError, ValueError):
                 log.error("Invalid Command-Id header. Headers: %s",
@@ -668,7 +669,7 @@ class Printer:
                               command_id=command_id,
                               reason=self.NOT_INITIALISED_MSG)
                 return res
-            content_type = res.headers.get("content-type", default="")
+            content_type = res.headers.get("content-type", "")
             log.debug("parse_command res: %s", res.text)
             try:
                 if content_type.startswith("application/json"):

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -6,7 +6,6 @@ from typing import ClassVar
 from unittest.mock import Mock
 
 import pytest
-from _pytest.python_api import raises
 
 from prusa.connect.printer import get_timestamp
 from prusa.connect.printer.camera import Camera, Resolution, Snapshot
@@ -182,7 +181,7 @@ def test_humpty_function():
     driver = DummyDriver(id1, available[id1], Mock())
     driver.connect()
     del driver._config[CapabilityType.RESOLUTION.value]
-    with raises(AttributeError):
+    with pytest.raises(AttributeError):
         camera = Camera(driver)
     driver = DummyDriver(id1, available[id1], Mock())
     driver.connect()
@@ -218,7 +217,7 @@ def test_humpty_function():
     assert camera.scheme_cb.call_args.args[1] == TriggerScheme.THIRTY_SEC
     assert camera.scheme_cb.call_args.args[2] == TriggerScheme.EACH_LAYER
 
-    with raises(NotSupported):
+    with pytest.raises(NotSupported):
         camera.rotation = 90
 
     driver.disconnected_cb.assert_not_called()
@@ -228,7 +227,7 @@ def test_humpty_function():
     driver = DummyDriver(id1, available[id1], Mock())
     driver.connect()
     driver._capabilities.add(CapabilityType.EXPOSURE)
-    with raises(DriverError):
+    with pytest.raises(DriverError):
         camera = Camera(driver)
         camera.exposure = 1
 
@@ -240,7 +239,7 @@ def test_humpty_function():
         }, Mock())
     driver.connect()
     assert driver.is_connected
-    with raises(RuntimeError):
+    with pytest.raises(RuntimeError):
         driver.set_resolution(Resolution(5, 5))
 
     driver = DummyDriver(
@@ -396,7 +395,7 @@ def test_configurator_remove_detected():
                                       drivers=[DummyDriver])
     id1 = CameraDriver.make_hash("id1")
     assert id1 in configurator.loaded
-    with raises(RuntimeError):
+    with pytest.raises(RuntimeError):
         configurator.remove_camera(id1)
 
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -19,16 +19,18 @@ GCODE_URL = ("https://files.printables.com/media/prints/27216/gcodes/"
 DST = '/sdcard/my_example.gcode'
 
 
-@responses.activate
 @pytest.fixture
-def gcode(printer):
+def gcode(printer):  # noqa: PT004
     # pylint: disable=unused-argument
-    responses.add(responses.GET,
-                  GCODE_URL,
-                  body=os.urandom(1024 * 1024),
-                  status=200,
-                  content_type="application/octet-stream",
-                  stream=True)
+    with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
+        rsps.add(responses.GET,
+                 GCODE_URL,
+                 body=os.urandom(1024 * 1024),
+                 status=200,
+                 content_type="application/octet-stream",
+                 headers={"Content-Length": str(1024 * 1024)},
+                 stream=True)
+        yield
 
 
 @pytest.fixture
@@ -207,7 +209,7 @@ def test_telemetry_sends_download_info(printer, gcode, download_mgr):
         assert 0, "test failed, `break` was not reached"
 
 
-def test_printed_file_cb(download_mgr, printer):
+def test_printed_file_cb(download_mgr, printer, gcode):
     """Transfer will be aborted if currently printed file is the same"""
     printer.queue.get_nowait()  # MEDIUM_INSERTED from attaching `tmp`
     download_mgr.printed_file_cb = lambda: \
@@ -283,7 +285,7 @@ def test_download_mgr_os_path(download_mgr):
         download_mgr.to_os_path('/sdcard/../foo/one')
 
 
-def test_download_finished_cb(download_mgr, printer):
+def test_download_finished_cb(download_mgr, printer, gcode):
     res = {}
 
     def download_finished_cb(transfer):


### PR DESCRIPTION
  - Use positional default arg for Mapping.get() to satisfy mypy overloads
  - Import raises from public pytest API instead of internal _pytest module
  - Fix decorator order on gcode fixture so pytest detects it correctly