### PR TITLE
Updated yapf in pre-commit from abandoned mirrors-yapf to google/yapf…

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -32,7 +32,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -U -r requirements.txt
         pip install -U types-requests
-        pip install -U ruff pytest pytest-pylint pytest-doctestplus
+        pip install -U ruff pytest pytest-doctestplus pylint
         pip install -U requests_mock pytest-mypy func-timeout responses
 
     - name: Lint with ruff
@@ -40,7 +40,10 @@ jobs:
         ruff check .
     - name: Lint with pylint
       run: |
-        pytest -v --mypy --pylint --doctest-plus --doctest-rst prusa/connect/printer
+        pylint prusa/connect/printer
+    - name: Type check and doctest
+      run: |
+        pytest -v --mypy --doctest-plus --doctest-rst prusa/connect/printer
     - name: Tests
       run: |
         TZ=Europe/Prague pytest -v --mypy tests --log-cli-level=10

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 ---
 repos:
-  - repo: https://github.com/pre-commit/mirrors-yapf
-    rev: 'v0.32.0'  # Use the sha / tag you want to point at
+  - repo: https://github.com/google/yapf
+    rev: 'v0.43.0'
     hooks:
       - id: yapf
-        additional_dependencies: [toml]
+        additional_dependencies: [tomli]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 ChangeLog
 =========
+0.9.0dev0
+    * linters update
+
 0.8.2 (2025-05-05)
     * Bump requests to 2.32.3
     * Set TLS config value fallabck to False

--- a/prusa/connect/printer/__init__.py
+++ b/prusa/connect/printer/__init__.py
@@ -35,7 +35,7 @@ from .models import (
 )
 from .util import RetryingSession, get_timestamp
 
-__version__ = "0.8.2"
+__version__ = "0.9.0dev0"
 __date__ = "5 May 2025"  # version date
 __copyright__ = "(c) 2025 Prusa 3D"
 __author_name__ = "Prusa Link Developers"

--- a/prusa/connect/printer/camera.py
+++ b/prusa/connect/printer/camera.py
@@ -80,6 +80,7 @@ class Snapshot:
 
 class Resolution:
     """A class to represent a camera resolution"""
+
     def __init__(self, width: int, height: int) -> None:
         self.width: int = width
         self.height: int = height
@@ -130,7 +131,9 @@ class Resolution:
 def value_setter(capability_type):
     """A decorator for methods setting a camera option while making sure
     it is valid"""
+
     def value_setter_decorator(func):
+
         def inner(camera: "Camera", value):
             # pylint: disable=protected-access
             old_value = camera.get_value(capability_type)
@@ -159,7 +162,9 @@ def value_setter(capability_type):
 
 def value_getter(capability_type):
     """A decorator for methods getting a camera option"""
+
     def value_getter_decorator(func):
+
         def inner(camera: "Camera"):
             if not camera.supports(capability_type):
                 raise NotSupported(

--- a/prusa/connect/printer/camera_controller.py
+++ b/prusa/connect/printer/camera_controller.py
@@ -25,6 +25,7 @@ class CameraController:
     """This component harbors functioning cameras, triggers them, sends out
     images to connect and should contain functionality needed for operating
     with functional cameras"""
+
     def __init__(self, session: Session, server: Optional[str],
                  send_cb: Callable[[LoopObject], None]) -> None:
         """

--- a/prusa/connect/printer/errors.py
+++ b/prusa/connect/printer/errors.py
@@ -31,6 +31,7 @@ class ErrorState:
     >>> str(leaf)
     'leaf: True'
     """
+
     def __init__(self, name, long_msg, prev=None, short_msg=None):
         self.name = name
         self.prev = prev

--- a/prusa/connect/printer/models.py
+++ b/prusa/connect/printer/models.py
@@ -17,19 +17,23 @@ log = getLogger("connect-printer")
 
 CODE_TIMEOUT = 60 * 30  # 30 min
 
-EventCallback = Callable[[
-    Arg(const.Event, 'event'),  # noqa
-    Arg(const.Source, 'source'),  # noqa
-    DefaultArg(Optional[float], 'timestamp'),  # noqa
-    DefaultArg(Optional[int], 'command_id'),  # noqa
-    KwArg(Any),
-], None]
+EventCallback = Callable[
+    [
+        Arg(const.Event, 'event'),  # noqa
+        Arg(const.Source, 'source'),  # noqa
+        DefaultArg(Optional[float], 'timestamp'),  # noqa
+        DefaultArg(Optional[int], 'command_id'),  # noqa
+        KwArg(Any),
+    ],
+    None]
 
-TelemetryCallback = Callable[[
-    Arg(const.State, 'state'),  # noqa
-    DefaultArg(Optional[float], 'timestamp'),  # noqa
-    KwArg(Any),
-], None]
+TelemetryCallback = Callable[
+    [
+        Arg(const.State, 'state'),  # noqa
+        DefaultArg(Optional[float], 'timestamp'),  # noqa
+        KwArg(Any),
+    ],
+    None]
 
 
 def filter_null(obj):

--- a/prusa/connect/printer/util.py
+++ b/prusa/connect/printer/util.py
@@ -33,6 +33,7 @@ class RetryingSession(requests.Session):
     #  Consider it a working fix until the problem is investigated more deeply
     #  and an eventually cleaner solution is found.
     """
+
     def __init__(self, max_retries=3):
         # pylint: disable=missing-function-docstring
         super().__init__()

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -91,6 +91,7 @@ class DummyDriver(CameraDriver):
 
 
 class AdditionalCamera:
+
     def __enter__(self):
         """Adds a camera to a scan"""
         DummyDriver.scanned_cameras["extra"] = {
@@ -157,6 +158,7 @@ class EventSetMock(Mock):
     """
     Sets its built in event when called, otherwise it's a regular mock
     """
+
     def __init__(self, *args, side_effect=None, **kwargs):
         if side_effect is not None:
             raise AttributeError("Do not provide a side effect to this mock, "

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -20,6 +20,7 @@ def queue():
 
 @pytest.fixture
 def command(queue):
+
     def create_event(event: const.Event,
                      source: const.Source,
                      timestamp: Optional[float] = None,
@@ -88,6 +89,7 @@ def test_finish(command, queue):
 
 
 def test_call(command, queue):
+
     def handler(caller):
         assert len(caller.args) == 0, caller.args
         return dict(event=const.Event.INFO, source=const.Source.CONNECT, x='x')
@@ -117,6 +119,7 @@ def test_call_not_implemented(command, queue):
 
 
 def test_call_exception(command, queue):
+
     def handler(caller):
         raise RuntimeError(str(caller.args))
 
@@ -141,6 +144,7 @@ def test_unknown(command, queue):
 
 
 def test_command_recall(command, queue):
+
     def handler(caller):
         assert len(caller.args) == 0, caller.args
         return dict(event=const.Event.INFO, source=const.Source.CONNECT, x='x')


### PR DESCRIPTION
Update yapf and fix pylint/pytest compatibility
    
 - Replace abandoned mirrors-yapf with google/yapf v0.43.0 in pre-commit
 - Replace deprecated pytest-pylint plugin (incompatible with pytest 8.x)
   with direct pylint invocation in CI workflow